### PR TITLE
Fix issues related to MariaDB 10.4 -> 10.5 upgrade

### DIFF
--- a/observium/Dockerfile
+++ b/observium/Dockerfile
@@ -51,10 +51,10 @@ RUN apt-get update -q && \
       wget pwgen at libvirt-bin && \
     apt-get update -q -y
 
-# Tweak my.cnf
-RUN sed -i -e 's#\(bind-address.*=\).*#\1 127.0.0.1#g' /etc/mysql/my.cnf && \
-    sed -i -e 's#\(log_error.*=\).*#\1 /config/databases/mysql_safe.log#g' /etc/mysql/my.cnf && \
-    sed -i -e 's/\(user.*=\).*/\1 nobody/g' /etc/mysql/my.cnf && \
+# Tweak MariaDB configuration
+RUN sed -i -e 's#\(bind-address.*=\).*#\1 127.0.0.1#g' /etc/mysql/mariadb.conf.d/50-server.cnf && \
+    sed -i -e 's#\(log_error.*=\).*#\1 /config/databases/mysql_safe.log#g' /etc/mysql/mariadb.conf.d/50-server.cnf && \
+    sed -i -e 's/\(user.*=\).*/\1 nobody/g' /etc/mysql/mariadb.conf.d/50-server.cnf && \
     echo '[mysqld]' > /etc/mysql/conf.d/innodb_file_per_table.cnf && \
     echo 'innodb_file_per_table' >> /etc/mysql/conf.d/innodb_file_per_table.cnf
 

--- a/observium/mariadb.sh
+++ b/observium/mariadb.sh
@@ -33,12 +33,13 @@ else
   echo "Shutting down."
   mysqladmin -u root shutdown
   sleep 1
-  echo "chown time"
-  chown -R nobody:users /config/databases
-  chmod -R 755 /config/databases
-  sleep 3
   echo "Initialization complete."
 fi
+
+echo "Fixing file permissions."
+chown -R nobody:users /config/databases
+chmod -R 755 /config/databases
+sleep 3
 
 echo "Starting MariaDB..."
 /usr/bin/mysqld_safe --skip-syslog --datadir='/config/databases'


### PR DESCRIPTION
Fix MariaDB configuration problems when upgrading MariaDB from 10.4 to 10.5.

The settings modified in the Dockerfile moved from` /etc/mysql/my.cnf` to `/etc/mysql/mariadb.conf.d/50-server.cnf`. This caused MariaDB to run as the `mysql` user instead of the `nobody` user. Some users experienced permission issues with the database files.
```
2020-08-13 18:02:43 0 [ERROR] mariadbd: File '/config/databases/aria_log_control' not found (Errcode: 13 "Permission denied")
2020-08-13 18:02:43 0 [ERROR] mariadbd: Got error 'Can't open file' when trying to use aria control file '/config/databases/aria_log
_control'
2020-08-13 18:02:43 0 [ERROR] Plugin 'Aria' init function returned error.
2020-08-13 18:02:43 0 [ERROR] Plugin 'Aria' registration as a STORAGE ENGINE failed.
2020-08-13 18:02:43 0 [Note] InnoDB: Using Linux native AIO
2020-08-13 18:02:43 0 [ERROR] InnoDB: The innodb_system data file 'ibdata1' must be writable
2020-08-13 18:02:43 0 [ERROR] InnoDB: The innodb_system data file 'ibdata1' must be writable
2020-08-13 18:02:43 0 [ERROR] Plugin 'InnoDB' init function returned error.
2020-08-13 18:02:43 0 [ERROR] Plugin 'InnoDB' registration as a STORAGE ENGINE failed.
2020-08-13 18:02:43 0 [Note] Plugin 'FEEDBACK' is disabled.
2020-08-13 18:02:43 0 [ERROR] Could not open mysql.plugin table: "Table 'mysql.plugin' doesn't exist". Some plugins may be not loade
d
2020-08-13 18:02:43 0 [ERROR] Failed to initialize plugins.
2020-08-13 18:02:43 0 [ERROR] Aborting
```
Also, make a change is to always change the database files owner to `nobody:users` and permissions to `755` in the mariadb.sh script, in case some files are still owned by the `mysql` user.