### PR TITLE
Syslog feature (updated)

### DIFF
--- a/observium/Dockerfile
+++ b/observium/Dockerfile
@@ -109,6 +109,10 @@ RUN rm /etc/apache2/sites-available/default-ssl.conf && \
 COPY cron-observium /etc/cron.d/observium
 RUN chmod 744 /etc/cron.d/observium
 
+# syslog config
+COPY observium.conf /etc/syslog-ng/conf.d/observium.conf
+
+EXPOSE 514/udp
 EXPOSE 8668/tcp
 
 VOLUME ["/config","/opt/observium/logs","/opt/observium/rrd"]

--- a/observium/README.md
+++ b/observium/README.md
@@ -50,6 +50,8 @@ If you do not specify a timezone, the timezone will be set to UTC.
 
 Browse to ```http://your-host-ip:8668``` and login with user and password `observium`
 
+To support syslog ingestion forward port 514 into docker (`-p 514:514/udp`).
+
 ---
 Credits
 ===

--- a/observium/firstrun.sh
+++ b/observium/firstrun.sh
@@ -18,7 +18,7 @@ else
 fi
 
 # if syslog config line is not already in config.php then add it
-grep -<span class="x x-first x-last">qF</span> 'enable_syslog' /config/config.php || echo "\$config['enable_syslog'] = 1;" &gt;&gt; /config/config.php
+grep -qF 'enable_syslog' /config/config.php || echo "\$config['enable_syslog'] = 1;" >> /config/config.php
 
 ln -s /config/config.php /opt/observium/config.php
 chown nobody:users -R /opt/observium

--- a/observium/firstrun.sh
+++ b/observium/firstrun.sh
@@ -18,7 +18,7 @@ else
 fi
 
 # if syslog config line is not already in config.php then add it
-grep -qxF 'enable_syslog' /config/config.php || echo "\$config['enable_syslog'] = 1;" >> /config/config.php
+grep -<span class="x x-first x-last">qF</span> 'enable_syslog' /config/config.php || echo "\$config['enable_syslog'] = 1;" &gt;&gt; /config/config.php
 
 ln -s /config/config.php /opt/observium/config.php
 chown nobody:users -R /opt/observium

--- a/observium/firstrun.sh
+++ b/observium/firstrun.sh
@@ -17,6 +17,9 @@ else
   sed -i -e 's/USERNAME/observium/g' /config/config.php
 fi
 
+# if syslog config line is not already in config.php then add it
+grep -qxF 'enable_syslog' /config/config.php || echo "\$config['enable_syslog'] = 1;" >> /config/config.php
+
 ln -s /config/config.php /opt/observium/config.php
 chown nobody:users -R /opt/observium
 chmod 755 -R /opt/observium

--- a/observium/observium.conf
+++ b/observium/observium.conf
@@ -1,0 +1,17 @@
+options {
+    chain_hostnames(0);
+    keep_hostname(1);
+    use_dns(no);
+    dns_cache(no);
+};
+source s_net {
+    udp();
+};
+
+destination d_observium { 
+    program("/opt/observium/syslog.php" template ("$HOST||$FACILITY||$LEVEL_NUM||$LEVEL||$TAG||$YEAR-$MONTH-$DAY $HOUR:$MIN:$SEC||$MSG||$PROGRAM\n") ); 
+ };
+ log {
+    source(s_net);
+    destination(d_observium);
+};


### PR DESCRIPTION
Hi @charlescng,

I have built and tested this locally and can confirm it works.
The `enable_syslog` setting is now appended to the config.php if it doesn't exist.

The error you reported:
> Aug 7 21:09:27 cd78ab882a38 syslog-ng[12]: Child program exited, restarting; cmdline='/opt/observium/syslog.php', status='0'

This happens in a loop when the container first starts. Once the database is up and running (which takes a little while) the error stops and it is able to record syslog entries.

![2021-09-27_16-06](https://user-images.githubusercontent.com/4302032/134935676-8e9dde3d-7f80-497f-a8b5-c3887994fe11.png)

(refs #15 )