### PR TITLE
Add syslog UDP port

### DIFF
--- a/unraid-templates/uberchuckie/observium.xml
+++ b/unraid-templates/uberchuckie/observium.xml
@@ -32,6 +32,11 @@
         <ContainerPort>8668</ContainerPort>
         <Protocol>tcp</Protocol>
       </Port>
+      <Port>
+        <HostPort>8514</HostPort>
+        <ContainerPort>514</ContainerPort>
+        <Protocol>udp</Protocol>
+      </Port>
     </Publish>
   </Networking>
   <Data>


### PR DESCRIPTION
Add UDP syslog port for https://github.com/charlescng/docker-containers/pull/20.

I didn't want to use port 514 on the host, in case it conflicts with any syslog server running on the host.

@exptom