### PR TITLE
Remove hardcoded poller instances

### DIFF
--- a/observium/cron-observium
+++ b/observium/cron-observium
@@ -1,6 +1,6 @@
 33  */6   * * *   root    /opt/observium/discovery.php -h all >> /dev/null 2>&1
 */5 *     * * *   root    /opt/observium/discovery.php -h new >> /dev/null 2>&1
-*/5 *     * * *   root    /opt/observium/poller-wrapper.py 2 >> /dev/null 2>&1
+*/5 *     * * *   root    /opt/observium/poller-wrapper.py >> /dev/null 2>&1
 # Run housekeeping script daily for syslog, eventlog and alert log
 13 5 * * * root /opt/observium/housekeeping.php -sel >> /dev/null 2>&1
 # Run housekeeping script daily for rrds, ports, orphaned entries in the database and performance data


### PR DESCRIPTION
The cron poller-wrapper is set to a hardcoded "2" poller instances. This is deprecated usage. Poller instances are fully configurable via the UI now.
I have recently added quite a few more hosts to observium and wondered why my poller was taking so long to complete! Removing the "2" has allowed the poller-wrapper to create more instances and resolved my issues.