### PR TITLE
Upgrade Observium, baseimage, and MariaDB

### DIFF
--- a/observium/Dockerfile
+++ b/observium/Dockerfile
@@ -2,7 +2,7 @@
 # sure you lock down to a specific version, not to `latest`!
 # See https://github.com/phusion/baseimage-docker/blob/master/Changelog.md for
 # a list of version numbers.
-FROM phusion/baseimage:focal-1.2.0
+FROM phusion/baseimage:jammy-1.0.1
 MAINTAINER uberchuckie <uberchuckie@gmail.com>
 
 # Set correct environment variables.
@@ -38,16 +38,16 @@ RUN locale-gen ru_RU.UTF-8
 RUN locale-gen sl_SI.UTF-8
 RUN locale-gen uk_UA.UTF-8
 
-RUN curl -sS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | bash -s -- --mariadb-server-version=mariadb-10.10 --skip-maxscale
+RUN curl -sS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | bash -s -- --mariadb-server-version=mariadb-10.11 --skip-maxscale
 
 # Install Observium prereqs
 RUN apt-get update -q && \
     apt-get upgrade -y -q && \
     apt-get install -y --no-install-recommends mariadb-server mariadb-client \
-      libapache2-mod-php7.4 php7.4-cli php7.4-mysql php7.4-mysqli php7.4-gd php7.4-json \
-      php-pear snmp fping python3-mysqldb rrdtool subversion whois mtr-tiny at \
-      nmap ipmitool graphviz imagemagick apache2 python3-pymysql python-is-python3 \
-      wget pwgen at libvirt-clients libvirt-daemon-system && \
+      libapache2-mod-php8.1 php8.1-cli php8.1-mysql php8.1-gd php8.1-bcmath php8.1-mbstring \
+      php8.1-opcache php8.1-curl php-apcu php-pear snmp fping rrdtool subversion \
+      whois mtr-tiny ipmitool graphviz imagemagick apache2 python3-mysqldb python3-pymysql python-is-python3 \
+      nmap wget pwgen at libvirt-clients libvirt-daemon-system && \
     apt-get update -q -y
 
 # Tweak MariaDB configuration

--- a/observium/firstrun.sh
+++ b/observium/firstrun.sh
@@ -25,11 +25,11 @@ chown nobody:users -R /opt/observium
 chmod 755 -R /opt/observium
 
 if [ -f /etc/container_environment/TZ ] ; then
-  sed -i "s#\;date\.timezone\ \=#date\.timezone\ \=\ $TZ#g" /etc/php/7.4/cli/php.ini
-  sed -i "s#\;date\.timezone\ \=#date\.timezone\ \=\ $TZ#g" /etc/php/7.4/apache2/php.ini
+  sed -i "s#\;date\.timezone\ \=#date\.timezone\ \=\ $TZ#g" /etc/php/8.1/cli/php.ini
+  sed -i "s#\;date\.timezone\ \=#date\.timezone\ \=\ $TZ#g" /etc/php/8.1/apache2/php.ini
 else
   echo "Timezone not specified by environment variable"
   echo UTC > /etc/container_environment/TZ
-  sed -i "s#\;date\.timezone\ \=#date\.timezone\ \=\ UTC#g" /etc/php/7.4/cli/php.ini
-  sed -i "s#\;date\.timezone\ \=#date\.timezone\ \=\ UTC#g" /etc/php/7.4/apache2/php.ini
+  sed -i "s#\;date\.timezone\ \=#date\.timezone\ \=\ UTC#g" /etc/php/8.1/cli/php.ini
+  sed -i "s#\;date\.timezone\ \=#date\.timezone\ \=\ UTC#g" /etc/php/8.1/apache2/php.ini
 fi


### PR DESCRIPTION
- Upgrade Observium CE to 23.1.12493 (26th January 2023)
- Upgrade baseimage to jammy-1.0.1
- Upgrade MariaDB to 10.11.2