### PR TITLE
Apply workaround for graph timezone always using UTC

### DIFF
--- a/observium/firstrun.sh
+++ b/observium/firstrun.sh
@@ -33,3 +33,7 @@ else
   sed -i "s#\;date\.timezone\ \=#date\.timezone\ \=\ UTC#g" /etc/php/8.1/cli/php.ini
   sed -i "s#\;date\.timezone\ \=#date\.timezone\ \=\ UTC#g" /etc/php/8.1/apache2/php.ini
 fi
+
+# Workaround graph times not using system/php/database TZ or TZ environment
+rm /etc/localtime
+ln -s /usr/share/zoneinfo/$(cat /etc/container_environment/TZ) /etc/localtime


### PR DESCRIPTION
Fix https://github.com/charlescng/docker-containers/issues/25

Even though the system, PHP, database and user timezones are all set correctly, the graphs always uses UTC for its timeseries.

It appears that the graphs are using `/etc/localtime`, even though `$TZ` is set correctly in the container.

The workaround is to link `/etc/localtime` to the right timezone based on the timezone setup in `firstrun.sh`.

Reference: https://forums.unraid.net/topic/75153-support-uberchuckie-observium/?do=findComment&comment=1073295