### PR TITLE
Update Dockerfile to fix build

### DIFF
--- a/observium/Dockerfile
+++ b/observium/Dockerfile
@@ -3,14 +3,14 @@
 # See https://github.com/phusion/baseimage-docker/blob/master/Changelog.md for
 # a list of version numbers.
 FROM phusion/baseimage:jammy-1.0.1
-MAINTAINER uberchuckie <uberchuckie@gmail.com>
+LABEL org.opencontainers.image.authors="uberchuckie@gmail.com"
 
 # Set correct environment variables.
-ENV HOME /root
-ENV DEBIAN_FRONTEND noninteractive
-ENV LC_ALL C.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
+ENV HOME=/root
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LC_ALL=C.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
 
 # Use baseimage-docker's init system
 CMD ["/sbin/my_init"]
@@ -38,7 +38,7 @@ RUN locale-gen ru_RU.UTF-8
 RUN locale-gen sl_SI.UTF-8
 RUN locale-gen uk_UA.UTF-8
 
-RUN curl -sS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | bash -s -- --mariadb-server-version=mariadb-10.11 --skip-maxscale
+RUN curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --mariadb-server-version=mariadb-10.11 --skip-maxscale
 
 # Install Observium prereqs
 RUN apt-get update -q && \


### PR DESCRIPTION
Fix download URL for the `mariadb_repo_setup` script and fix Dockerfile deprecation warnings.