### PR TITLE
Enable SSL/TLS and SMTP support

### DIFF
--- a/observium/Dockerfile
+++ b/observium/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update -q && \
       libapache2-mod-php8.3 php8.3-cli php8.3-mysql php8.3-gd php8.3-bcmath php8.3-mbstring \
       php8.3-opcache php8.3-curl php-apcu php-pear snmp fping rrdtool subversion \
       whois mtr-tiny ipmitool graphviz imagemagick apache2 python3-mysqldb python3-pymysql python-is-python3 \
-      nmap wget pwgen at libvirt-clients libvirt-daemon-system && \
+      nmap wget pwgen at libvirt-clients libvirt-daemon-system openssl sendmail && \
     apt-get update -q -y
 
 # Tweak MariaDB configuration
@@ -63,7 +63,7 @@ RUN mkdir -p /opt/observium/firstrun /opt/observium/logs /opt/observium/rrd /con
     tar zxvf observium-community-latest.tar.gz && \
     rm observium-community-latest.tar.gz
 
-RUN a2enmod rewrite
+RUN a2enmod rewrite ssl
 
 RUN mkdir /etc/service/apache2
 COPY apache2.sh /etc/service/apache2/run
@@ -107,8 +107,9 @@ COPY observium.conf /etc/syslog-ng/conf.d/observium.conf
 
 EXPOSE 514/udp
 EXPOSE 8668/tcp
+EXPOSE 8669/tcp
 
-VOLUME ["/config","/opt/observium/logs","/opt/observium/rrd"]
+VOLUME ["/config","/opt/observium/logs","/opt/observium/rrd","/opt/observium/certificates"]
 
 # Clean up APT when done.
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/observium/README.md
+++ b/observium/README.md
@@ -24,7 +24,7 @@ cd observium
 docker build -t uberchuckie/observium .
 ```
 
-You can also obtain it via:  
+You can also obtain it via:
 
 ```
 docker pull uberchuckie/observium
@@ -51,6 +51,21 @@ If you do not specify a timezone, the timezone will be set to UTC.
 Browse to ```http://your-host-ip:8668``` and login with user and password `observium`
 
 To support syslog ingestion forward port 514 into docker (`-p 514:514/udp`).
+
+---
+Running the container with SSL/TLS
+===
+
+Create the certificate directory and drop/link there two files: 
+- fullchain.pem - only certificate, certificate with CA or certificate with CA and intermediate certificate chain (https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcertificatefile)
+- privkey.pem - private key (https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcertificatekeyfile)
+
+Start the container:
+```
+docker run -d -v /your-config-location:/config -v /path-to-logs:/opt/observium/logs -v /path-to-certificates:/opt/observium/certificates -v /path-to-rrds:/opt/observium/rrd -e TZ="America/Chicago" -p 8669:8669 uberchuckie/observium
+```
+
+Browse to ```http://your-host-ip:8669``` and login with user and password `observium`
 
 ---
 Credits

--- a/observium/apache-observium
+++ b/observium/apache-observium
@@ -1,3 +1,4 @@
+# Plain part
 <VirtualHost *:8668>
        ServerAdmin webmaster@localhost
        DocumentRoot /opt/observium/html
@@ -14,4 +15,27 @@
        LogLevel warn
        CustomLog  /opt/observium/logs/access_log combined
        ServerSignature On
+</VirtualHost>
+
+# SSL part
+<VirtualHost *:8669>
+       ServerAdmin webmaster@localhost
+       DocumentRoot /opt/observium/html
+       <Directory />
+               Options FollowSymLinks
+               AllowOverride None
+       </Directory>
+       <Directory /opt/observium/html/>
+              Options Indexes FollowSymLinks MultiViews
+              AllowOverride All
+              Require all granted
+      </Directory>
+       ErrorLog  /opt/observium/logs/error_log
+       LogLevel warn
+       CustomLog  /opt/observium/logs/access_log combined
+       ServerSignature On
+       SSLEngine On
+       # only one certificate, certificate with CA or intermediate certificate
+       SSLCertificateFile "/opt/observium/certificates/fullchain.pem"
+       SSLCertificateKeyFile "/opt/observium/certificates/privkey.pem"
 </VirtualHost>

--- a/observium/firstrun.sh
+++ b/observium/firstrun.sh
@@ -1,5 +1,37 @@
 #!/bin/bash
 
+# Generate self signed certificate if certificates folder is empty
+# Define the folder to check and certificate details
+CERT_DIR="/opt/observium/certificates"
+CERT_FILE="$CERT_DIR/fullchain.pem"
+KEY_FILE="$CERT_DIR/privkey.pem"
+
+# Check if the folder exists and is empty
+if [ ! -d "$CERT_DIR" ]; then
+  echo "Directory $CERT_DIR does not exist. Creating it..."
+  mkdir -p "$CERT_DIR"
+fi
+
+if [ "$(ls -A $CERT_DIR)" ]; then
+  echo "Directory $CERT_DIR is not empty. No certificate will be generated."
+else
+  echo "Directory $CERT_DIR is empty. Generating self-signed certificate..."
+
+  # Generate a self-signed certificate
+  openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+    -keyout "$KEY_FILE" \
+    -out "$CERT_FILE" \
+    -subj "/C=DE/ST=Mecklenburg-Vorpommern/L=Dummerstorf/O=FBN/OU=IT/CN=localhost"
+
+  if [ $? -eq 0 ]; then
+    echo "Self-signed certificate and key generated successfully:"
+    echo "Certificate: $CERT_FILE"
+    echo "Key: $KEY_FILE"
+  else
+    echo "Failed to generate the self-signed certificate."
+  fi
+fi
+
 atd
 
 # Check if PHP database config exists. If not, copy in the default config

--- a/observium/mariadb.sh
+++ b/observium/mariadb.sh
@@ -39,6 +39,9 @@ fi
 echo "Fixing file permissions."
 chown -R nobody:users /config/databases
 chmod -R 755 /config/databases
+chown -R nobody:users /run/mysqld
+chmod -R 755 /run/mysqld
+
 sleep 3
 
 echo "Starting MariaDB..."

--- a/observium/ports.conf
+++ b/observium/ports.conf
@@ -3,5 +3,6 @@
 # /etc/apache2/sites-enabled/000-default.conf
 
 Listen 8668
+Listen 8669
 
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
This commit enables SSL/TLS support in Apache. If no certificates are specified, self-signed certificates will be created. The sendmail package is also being installed. This allows email sending via SMTP from Observium.