### PR TITLE
feat: Add reverse proxy and dynamic base_url support

### DIFF
--- a/observium/Dockerfile
+++ b/observium/Dockerfile
@@ -63,7 +63,7 @@ RUN mkdir -p /opt/observium/firstrun /opt/observium/logs /opt/observium/rrd /con
     tar zxvf observium-community-latest.tar.gz && \
     rm observium-community-latest.tar.gz
 
-RUN a2enmod rewrite ssl
+RUN a2enmod rewrite ssl remoteip headers
 
 RUN mkdir /etc/service/apache2
 COPY apache2.sh /etc/service/apache2/run

--- a/observium/apache-observium
+++ b/observium/apache-observium
@@ -2,6 +2,14 @@
 <VirtualHost *:8668>
        ServerAdmin webmaster@localhost
        DocumentRoot /opt/observium/html
+
+       RemoteIPHeader X-Forwarded-For
+       RemoteIPTrustedProxy 10.0.0.0/8
+       RemoteIPTrustedProxy 172.16.0.0/12
+       RemoteIPTrustedProxy 192.168.0.0/16
+
+       SetEnvIf X-Forwarded-Proto "https" HTTPS=on
+
        <Directory />
                Options FollowSymLinks
                AllowOverride None

--- a/observium/firstrun.sh
+++ b/observium/firstrun.sh
@@ -48,13 +48,30 @@ else
   sed -i -e 's/PASSWORD/'$PW'/g' /config/config.php
   sed -i -e 's/USERNAME/observium/g' /config/config.php
 fi
-
 # if syslog config line is not already in config.php then add it
 grep -qF 'enable_syslog' /config/config.php || echo "\$config['enable_syslog'] = 1;" >> /config/config.php
+
+# Add dynamic base_url and reverse proxy support to config.php
+grep -qF 'Dynamic base_url detection' /config/config.php || cat <<'EOF' >> /config/config.php
+
+// --- Dynamic base_url detection ---
+if (isset($_SERVER['HTTP_HOST'])) {
+    if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+        $_SERVER['HTTPS'] = 'on';
+    }
+    $protocol = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') ? 'https' : 'http';
+    $host = $_SERVER['HTTP_HOST'];
+    $prefix = isset($_SERVER['HTTP_X_FORWARDED_PREFIX']) ? rtrim($_SERVER['HTTP_X_FORWARDED_PREFIX'], '/') : '';
+    $script_path = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/\\');
+    $config['base_url'] = $protocol . "://" . $host . $prefix . $script_path . "/";
+}
+// ----------------------------------
+EOF
 
 ln -s /config/config.php /opt/observium/config.php
 chown nobody:users -R /opt/observium
 chmod 755 -R /opt/observium
+chmod 755 /config/config.php
 
 if [ -f /etc/container_environment/TZ ] ; then
   sed -i "s#\;date\.timezone\ \=#date\.timezone\ \=\ $TZ#g" /etc/php/8.3/cli/php.ini


### PR DESCRIPTION
This PR adds support for running Observium behind a reverse proxy (like Tailscale Serve) by:
- Enabling 'remoteip' and 'headers' Apache modules.
- Configuring Apache to trust 'X-Forwarded-For' headers.
- Injecting dynamic PHP code into 'config.php' to automatically detect the protocol (HTTP/HTTPS) and base path (including subpaths) from request headers.

This allows Observium to function correctly at both the root '/' and subpaths '/observium/' without any manual configuration or hardcoded environment variables.